### PR TITLE
Restrict track report generation to tracks directory and simplify Markdown formatting

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,0 @@
-{
-  "MD025": false,
-  "MD013": false,
-  "MD024": false,
-  "MD029": false
-}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 .PHONY: install linters precommit test lint type fmt ci \
-        format-md fmt-json lint-md fix-md validate-stats tracks-report tracks-table markdown build
+        format-md fmt-json validate-stats tracks-report tracks-table markdown build
 
 # Prefer project venv Python, then python3, then python
 PYTHON := $(shell if [ -x "./venv/bin/python" ]; then echo "./venv/bin/python"; \
@@ -67,7 +67,7 @@ ci: test lint type validate-stats
 validate-stats:
 	$(PYTHON) scripts/validate_stats.py
 
-# Generate markdown reports for all tracks
+# Generate markdown reports for tracks in tracks/
 tracks-report:
 	$(PYTHON) scripts/generate_track_reports.py
 
@@ -88,8 +88,6 @@ build:
 	make fmt-json
 	@echo "--- Running linters ---"
 	make lint
-	@echo "--- Linting Markdown ---"
-	make lint-md || true
 	@echo "--- Type checking ---"
 	make type
 	@echo "--- Running tests ---"
@@ -124,18 +122,3 @@ else
 	  (echo "--- Re-running pre-commit after auto-fixes ---" && $(PYTHON) -m pre_commit run --all-files) || true
 endif
 
-# Target: fix-md
-# Automatically fixes all supported Markdown linting issues using markdownlint.
-# Respects the .gitignore file. This target should be used locally.
-fix-md:
-	@echo "--- Fixing Markdown files with markdownlint ---"
-	markdownlint --fix "**/*.md" --ignore-path .gitignore .
-
-# Target: lint-md
-# Checks Markdown files for formatting and style issues without modifying them.
-# Ideal for CI pipelines. Fails if any issues are found.
-lint-md:
-	@echo "--- Checking Markdown formatting (mdformat) ---"
-	$(PYTHON) -m mdformat --check README.md docs problems tracks archive topics
-	@echo "--- Linting Markdown files (markdownlint) ---"
-	markdownlint --ignore-path .gitignore . --config .markdownlint.json

--- a/scripts/generate_track_reports.py
+++ b/scripts/generate_track_reports.py
@@ -85,9 +85,8 @@ def generate_for_track(yaml_path: Path) -> Path:
     description = str(data.get("description") or "")
     problems = data.get("problems") or []
     rows: list[dict] = []
-    # Always emit Markdown reports into ROOT/tracks regardless of YAML location.
+    # Emit Markdown reports into ROOT/tracks.
     out_path = (ROOT / "tracks" / yaml_path.stem).with_suffix(".md")
-    # link_base = out_path.parent
     for item in problems:
         slug = kebab(str(item.get("slug") or "").strip())
         disp_title = str(item.get("title") or slug.replace("-", " ").title())
@@ -174,8 +173,7 @@ def generate_for_track(yaml_path: Path) -> Path:
 
 def main(argv: list[str]) -> int:
     tracks_dir = ROOT / "tracks"
-    archive_dir = ROOT / "archive"
-    yaml_files = sorted(list(tracks_dir.glob("*.yaml")) + list(archive_dir.glob("track_*.yaml")))
+    yaml_files = sorted(tracks_dir.glob("*.yaml"))
     if not yaml_files:
         print("No track YAML files found.")
         return 0


### PR DESCRIPTION
## Summary
- Generate track markdown only from `tracks/*.yaml`
- Clarify Makefile target to note track reports come from `tracks/`
- Drop unused variable in track report generator
- Remove `markdownlint` config and targets, leaving `mdformat` as the sole Markdown formatter

## Testing
- `make lint`
- `make test`
- `make tracks-report`


------
https://chatgpt.com/codex/tasks/task_e_68bdb9bbd244832f8ba7bed4c96d0003